### PR TITLE
Fix is_final check in can_flush()

### DIFF
--- a/odc/geo/cog/_mpu.py
+++ b/odc/geo/cog/_mpu.py
@@ -188,7 +188,7 @@ class MPUChunk:
             return len(_data)
 
         def can_flush(pw: PartsWriter):
-            if self.write_credits < 1:
+            if self.write_credits < 1 and not self.is_final:
                 return False
             if self.started_write:
                 return self.is_final or len(data) >= pw.min_write_sz


### PR DESCRIPTION
Implements @jerry-kobold's proposed fix of `save_cog_with_dask` in https://github.com/opendatacube/odc-geo/issues/185.